### PR TITLE
Add github pointer for gem in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### Gemfile
 
 ```ruby
-gem 'activeadmin-dragonfly'
+gem 'activeadmin-dragonfly', github: 'stefanoverna/activeadmin-dragonfly'
 ```
 
 ### Model


### PR DESCRIPTION
Added reference to github project when including gem in a Gemfile. This change might save someone a minute or two tracking down where the gem can be installed from.
