### PR TITLE
Dragonfly::Middleware is already loaded

### DIFF
--- a/lib/active_admin/dragonfly/engine.rb
+++ b/lib/active_admin/dragonfly/engine.rb
@@ -9,8 +9,6 @@ module ActiveAdmin
         unless ActiveRecord::Base.methods.include? :image_accessor
           require 'dragonfly/rails/images'
         end
-        # in any case we add the Dragonfly[:images] app as middleware
-        app.config.middleware.insert 1, 'Dragonfly::Middleware', :images
 
         app.config.assets.precompile += [
           "active_admin/active_admin_dragonfly.js",


### PR DESCRIPTION
Dragonfly::Middleware is already loaded in 'dragonfly/rails/images'.
if you insert Dragonfly::Middleware middleware again you'll obtain 2 middleware in stack.
(see rake middleware)
