### PR TITLE
update dragonfly version to ~>1.0

### DIFF
--- a/activeadmin-dragonfly.gemspec
+++ b/activeadmin-dragonfly.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "activeadmin"
-  s.add_dependency "dragonfly", "0.9.15"
+  s.add_dependency "dragonfly", "~> 1.0"
   s.add_dependency "rack-cache"
 end
 

--- a/lib/active_admin/dragonfly/engine.rb
+++ b/lib/active_admin/dragonfly/engine.rb
@@ -5,10 +5,6 @@ module ActiveAdmin
 
     class Engine < ::Rails::Engine
       initializer "Railsyard precompile hook", group: :all do |app|
-        # check if someone already initialized Dragonfly for Rails
-        unless ActiveRecord::Base.methods.include? :image_accessor
-          require 'dragonfly/rails/images'
-        end
 
         app.config.assets.precompile += [
           "active_admin/active_admin_dragonfly.js",

--- a/lib/active_admin/dragonfly/version.rb
+++ b/lib/active_admin/dragonfly/version.rb
@@ -1,5 +1,5 @@
 module ActiveAdmin
   module Dragonfly
-    VERSION = "0.0.2"
+    VERSION = "0.1.0"
   end
 end


### PR DESCRIPTION
I have updated dragonfly versions to support the current version of [dragonfly-s3_data_store](https://github.com/markevans/dragonfly-s3_data_store). This will break the current version of [activeadmin-wysihtml5](https://github.com/stefanoverna/activeadmin-wysihtml5), which I have also patched to support dragonfly ~>1.0
